### PR TITLE
Fix to allow the combobox contents to show above the dialog box z-index

### DIFF
--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.theme.bootstrap/resources/web/extlib/responsive/xpages/css/xsp-mixin.css
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.theme.bootstrap/resources/web/extlib/responsive/xpages/css/xsp-mixin.css
@@ -1065,6 +1065,16 @@ div.glyphicon.xspReadIcon{
 	font-size: 28px;
 }
 
+/* dojo dialogs - Fix z-index to allow comboboxs to show ABOVE the dialog. */
+.xspmodal {
+	z-index:950 !important;
+}
+
+.dijitDialogUnderlayWrapper {
+	z-index: 949 !important;
+}
+
+
 /* dojo border container/pane - needs more work
 .dijitSplitContainer-child, .dijitBorderContainer-child {
     border: 1px solid #CCCCCC;


### PR DESCRIPTION
The dialog box z-index is set higher then the combo box z-index. This fix lowers the dialog box z-index down so that a combo box on the dialog will appear correctly.