### PR TITLE
Sbasegmez

### DIFF
--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.relational/src/com/ibm/xsp/extlib/relational/jdbc/datasource/dbcp/DbcpPoolDataSource.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.relational/src/com/ibm/xsp/extlib/relational/jdbc/datasource/dbcp/DbcpPoolDataSource.java
@@ -69,7 +69,9 @@ public  class DbcpPoolDataSource implements IJdbcResourceFactory {
 
                     Properties properties = new Properties();
                     properties.setProperty("user", username); // $NON-NLS-1$
-                    properties.setProperty("password", password); // $NON-NLS-1$
+
+                    // We should support empty password
+                    properties.setProperty("password", (null==password ? "":password)); // $NON-NLS-1$
 
                     ConnectionFactory connectionFactory = new DriverConnectionFactory(driver, url, properties);
 

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.theme.bootstrap/src/com/ibm/xsp/theme/bootstrap/ResourceHandler.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.theme.bootstrap/src/com/ibm/xsp/theme/bootstrap/ResourceHandler.java
@@ -10,7 +10,8 @@ public class ResourceHandler {
     private static ExtLibResourceHandlerImpl impl(){
         if (s_impl == null) {
             s_impl = AccessController.doPrivileged(new PrivilegedAction<ExtLibResourceHandlerImpl>() {
-                public ExtLibResourceHandlerImpl run() {
+                @Override
+				public ExtLibResourceHandlerImpl run() {
                     // privileged code goes here:
                     return new ExtLibResourceHandlerImpl(ResourceHandler.class, 
                             "messages", //$NON-NLS-1$


### PR DESCRIPTION
When using DBCP typed Jdbc file for relational, it gets the password using DOMAccessor and transfer it to the DbcpPoolDataSource. However, in testing, I use empty passwords which are passed as null which throws NPE in the Properties object.

Also added a Missing @Override annotation in a class (no big deal)
