### PR TITLE
Fulltext searches in Domino return a score (available as Document.FTS…

### DIFF
--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonDocumentCollectionContent.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonDocumentCollectionContent.java
@@ -125,6 +125,10 @@ public class JsonDocumentCollectionContent extends JsonContent {
             writeProperty(jwriter, RestServiceConstants.ATTR_UNID, unid);
             String link = _uri + unid;
             writeProperty(jwriter, RestServiceConstants.ATTR_HREF, link);
+            int score = document.getFTSearchScore();
+            if (score != 0) {
+            	writeProperty(jwriter, RestServiceConstants.ATTR_SCORE, score);
+            }
         } finally {
             jwriter.endArrayItem();     
             jwriter.endObject();

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonDocumentContent.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonDocumentContent.java
@@ -30,6 +30,7 @@ import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_HREF;
 import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_MODIFIED;
 import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_NOTEID;
 import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_PARENTID;
+import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_SCORE;
 import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_TYPE;
 import static com.ibm.domino.services.rest.RestServiceConstants.ATTR_UNID;
 import static com.ibm.domino.services.rest.RestServiceConstants.ITEM_FILE;
@@ -174,6 +175,13 @@ public class JsonDocumentContent extends JsonContent {
         }
         if ((sysItem & DocumentParameters.SYS_ITEM_AUTHORS)!=0) {
             writeProperty(jsonWriter, ATTR_AUTHORS, document.getAuthors());         
+        }
+        if ((sysItem & DocumentParameters.SYS_ITEM_SCORE)!=0) {
+        	int score = document.getFTSearchScore();
+        	// As this is always a new request/session, score seems always to be 0?
+        	if (score != 0) {
+        		writeProperty(jsonWriter, ATTR_SCORE, document.getFTSearchScore());
+        	}
         }
         if ((sysItem & DocumentParameters.SYS_ITEM_FORM)!=0) {
             String form = document.getItemValueString(ITEM_FORM);

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonViewEntryCollectionContent.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/content/JsonViewEntryCollectionContent.java
@@ -301,6 +301,16 @@ public class JsonViewEntryCollectionContent extends JsonContent {
                 jsonWriter.endProperty();
             }
         }
+        if((syscol & ViewParameters.SYSCOL_SCORE)!=0) {
+            int score = navigator.getScore();
+            if(forceDefaultAttributes || score>0) {
+                jsonWriter.startProperty(ATTR_SCORE);
+                jsonWriter.outIntLiteral(score);
+                jsonWriter.endProperty();
+            }
+        }
+
+        
     }
     
     protected void writeColumn(JsonWriter jsonWriter, RestViewNavigator navigator, int colIdx, String colName, Object colValue) throws IOException, ServiceException {

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/RestServiceConstants.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/RestServiceConstants.java
@@ -32,6 +32,7 @@ public class RestServiceConstants {
     public static final String ATTR_CONTENT = "content"; //$NON-NLS-1$
     public static final String ATTR_MESSAGE = "message"; //$NON-NLS-1$
     public static final String ATTR_TYPE = "type"; //$NON-NLS-1$
+    public static final String ATTR_SCORE = "@score"; //$NON-NLS-1$
 
     // View service attributes names used in JsonWriter
     public static final String ATTR_ENTRYID = "@entryid"; //$NON-NLS-1$
@@ -144,6 +145,7 @@ public class RestServiceConstants {
     public static final String ATTR_XML_COLUMNNUMBER = "columnnumber"; //$NON-NLS-1$
     public static final String ATTR_XML_NAME = "name"; //$NON-NLS-1$
     public static final String ATTR_XML_VIEWENTRIES = "viewentries"; //$NON-NLS-1$
+    public static final String ATTR_XML_SCORE = "score"; //$NON-NLS-1$
     public static final String ATTR_XML_VIEWENTRY = ATTR_VIEWENTRY; //$NON-NLS-1$
     public static final String ATTR_XML_ENTRYDATA = ATTR_ENTRYDATA; //$NON-NLS-1$
     public static final String ATTR_XML_TEXT = ATTR_TEXT; //$NON-NLS-1$

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/document/DocumentParameters.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/document/DocumentParameters.java
@@ -41,6 +41,7 @@ public interface DocumentParameters extends DominoParameters {
 	public static final int SYS_ITEM_AUTHORS = 0x0020;
 	public static final int SYS_ITEM_HIDDEN = 0x0040;
 	public static final int SYS_ITEM_FORM = 0x0080;
+	public static final int SYS_ITEM_SCORE = 0x0100;
 	public static final int SYS_ITEM_ALL = 0xFFFFFFFF;
 
 	// Check

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewEntry.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewEntry.java
@@ -33,6 +33,7 @@ public interface RestViewEntry {
 	public abstract int getDescendants() throws ServiceException;
 	public abstract int getChildren() throws ServiceException;
 	public abstract int getIndent() throws ServiceException;
+	public abstract int getScore() throws ServiceException;
 	
 	// Column values
 	public abstract int getColumnCount() throws ServiceException;

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewJsonLegacyService.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewJsonLegacyService.java
@@ -185,6 +185,16 @@ public class RestViewJsonLegacyService extends RestViewLegacyService {
             }
             g.endProperty();
         }
+        @Override
+        public void writeSystemScore(int score) throws IOException {
+            g.startProperty(ATTR_SCORE);
+            if(jsonTyped) {
+                g.outIntLiteral(score);
+            } else {
+                g.outStringLiteral(Integer.toString(score));
+            }
+            g.endProperty();
+        }
         
         @Override
         public void startEntryData() throws IOException {

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewLegacyService.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewLegacyService.java
@@ -75,7 +75,8 @@ public abstract class RestViewLegacyService extends RestViewService {
 		public abstract void writeSystemDescendants(int count) throws IOException;
 		public abstract void writeSystemChildren(int count) throws IOException;
 		public abstract void writeSystemIndent(int indent) throws IOException;
-
+		public abstract void writeSystemScore(int score) throws IOException;
+			
 		public abstract void startEntryData() throws IOException;
 		public abstract void endEntryData() throws IOException;
 
@@ -182,8 +183,13 @@ public abstract class RestViewLegacyService extends RestViewService {
 				g.writeSystemIndent(indent);
 			}
 		}
-		
-		
+		if((syscol & ViewParameters.SYSCOL_SCORE)!=0) {
+			int score = nav.getScore();
+			if(forceDefaultAttributes || score>0) {
+				g.writeSystemScore(score);
+			}
+		}
+
 		g.startEntryData();
 		// Read the default columns
 		int colidx = 0;

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewNavigator.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewNavigator.java
@@ -67,6 +67,7 @@ public abstract class RestViewNavigator implements RestViewEntry {
 	public abstract int getDescendants() throws ServiceException;
 	public abstract int getChildren() throws ServiceException;
 	public abstract int getIndent() throws ServiceException;
+	public abstract int getScore() throws ServiceException;
 	public abstract String getForm() throws ServiceException;
 	
 	// Column values

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewNavigatorFactory.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewNavigatorFactory.java
@@ -210,6 +210,14 @@ public class RestViewNavigatorFactory {
             }
         }
         @Override
+        public int getScore() throws ServiceException {
+            try {
+                return entry.getFTSearchScore();
+            } catch(NotesException ex) {
+                throw new ServiceException(ex,""); // $NON-NLS-1$
+            }
+        }
+        @Override
         public boolean isDocument() throws ServiceException {
             try {
                 return entry.isDocument();
@@ -375,6 +383,8 @@ public class RestViewNavigatorFactory {
         public int getChildren() throws ServiceException {throw new IllegalStateException();}
         @Override
         public int getIndent() throws ServiceException {throw new IllegalStateException();}
+        @Override
+        public int getScore() throws ServiceException {throw new IllegalStateException();}
         @Override
         public int getColumnCount() throws ServiceException {throw new IllegalStateException();}
         @Override

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewXmlLegacyService.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/RestViewXmlLegacyService.java
@@ -124,6 +124,10 @@ public class RestViewXmlLegacyService extends RestViewLegacyService {
         public void writeSystemIndent(int indent) throws IOException {
             g.writeAttribute(ATTR_XML_INDENT,indent);
         }
+        @Override
+        public void writeSystemScore(int score) throws IOException {
+            g.writeAttribute(ATTR_XML_SCORE,score);
+        }
         
         @Override
         public void startEntryData() throws IOException {

--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/ViewParameters.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.domino.services/src/com/ibm/domino/services/rest/das/view/ViewParameters.java
@@ -46,6 +46,7 @@ public interface ViewParameters extends DominoParameters {
 	public static final int SYSCOL_RESPONSE = 0x0400;
 	public static final int SYSCOL_HREF = 0x0800;
 	public static final int SYSCOL_LINK = 0x1000;
+	public static final int SYSCOL_SCORE = 0x2000;
 	//public static final int SYSCOL_ENTRYID = 0x2000;
 		
 	public static final int SYSCOL_ALL = 0xFFFFFFFF;


### PR DESCRIPTION
…earchScore).

This patch makes this score as @score available in the
Domino Access Services (REST Services), for sorting documents from multiple requests
to different databases.

Commit-Ersteller: Hans-Helmut Bühmann github@hans-helmut.buehmann.de
