### PR TITLE
Update JsonJdbcQueryContent.java

### DIFF
--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.relational/src/com/ibm/xsp/extlib/relational/jdbc/services/content/JsonJdbcQueryContent.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.relational/src/com/ibm/xsp/extlib/relational/jdbc/services/content/JsonJdbcQueryContent.java
@@ -1,5 +1,5 @@
 /*
- * © Copyright IBM Corp. 2011, 2015
+ * Â© Copyright IBM Corp. 2011, 2015
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License. 
@@ -235,7 +235,11 @@ public class JsonJdbcQueryContent extends JsonContent {
                                         writeProperty(jwriter, columnDefs[i].getName(), 
                                             (Boolean)columnValue);
                                     }
-                                    else {
+                                    else if (columnValue == null) {
+                                        jwriter.startProperty(columnDefs[i].getName());
+                                        jwriter.outNull();
+                                        jwriter.endProperty();
+                                    } else {
                                         writeProperty(jwriter, columnDefs[i].getName(), 
                                             columnValue.toString());
                                     }


### PR DESCRIPTION
When returning a jdbc query via json through the Jdbcqueryrest service, there is no check for null when writing the column values.
This means if any column values are null it will throw a null pointer exception and get an Error 500.
This can be handled by checking for null and outputting null , or alternatively you can just ignore it and not output any property ? in any case, it should try to avoid the null pointer exception.
