### PR TITLE
Bugfix so that you can clear a single Cache entry in userBean / peopleBean

### DIFF
--- a/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.controls/src/com/ibm/xsp/extlib/social/impl/AbstractResourceProvider.java
+++ b/extlib/lwp/product/runtime/eclipse/plugins/com.ibm.xsp.extlib.controls/src/com/ibm/xsp/extlib/social/impl/AbstractResourceProvider.java
@@ -285,9 +285,9 @@ public abstract class AbstractResourceProvider implements ResourceDataProvider {
             case ResourceDataProvider.SCOPE_APPLICATION: {
                 Map<String, Object> map = getApplicationMap(FacesContext.getCurrentInstance().getExternalContext());
                 SystemCache c = (SystemCache)map.get(CACHE_KEY);
-                if(c==null) {
-                    synchronized(map) {
-                        map.remove(CACHE_KEY);
+                if(c!=null) {
+                    synchronized(c) {                   	
+                    	c.remove(id);
                     }
                 }
                 return;
@@ -295,9 +295,9 @@ public abstract class AbstractResourceProvider implements ResourceDataProvider {
             case ResourceDataProvider.SCOPE_SESSION: {
                 Map<String, Object> map = TypedUtil.getSessionMap(FacesContext.getCurrentInstance().getExternalContext());
                 SystemCache c = (SystemCache)map.get(CACHE_KEY);
-                if(c==null) {
-                    synchronized(map) {
-                        map.remove(CACHE_KEY);
+                if(c!=null) {
+                    synchronized(c) {                  	
+                    	c.remove(id);
                     }
                 }
                 return;
@@ -305,9 +305,9 @@ public abstract class AbstractResourceProvider implements ResourceDataProvider {
             case ResourceDataProvider.SCOPE_REQUEST: {
                 Map<String, Object> map = TypedUtil.getRequestMap(FacesContext.getCurrentInstance().getExternalContext());
                 SystemCache c = (SystemCache)map.get(CACHE_KEY);
-                if(c==null) {
-                    synchronized(map) {
-                        map.remove(CACHE_KEY);
+                if(c!=null) {
+                    synchronized(c) {
+                        c.remove(id);
                     }
                 }
                 return;


### PR DESCRIPTION
Due to incorrect logic it was impossible to clear the cache / refresh for a single entry in the cache.

For example when using the userBean / peopleBean, if you tried to use peopleBean.clearCache(@UserName) it had no effect.

e.g. this was annoying if you added some accessRoles to user and just wanted to refresh that user's peopleBean entry.
[As specified in this StackOverflow question](http://stackoverflow.com/questions/22829780/extension-library-userbean-cache)

This is because of 3 bugs in the clearCache method
1. the tests for each scope if (c==null) should actually be if (c!=null). This was preventing the code from entering into the 'remove' condition
2. The 'remove' method was incorrectly being called on the scope map e.g. sessionScope instead of the system cache that was retrieved
3. The 'remove' method was using the 'CACHE_KEY' when it should actually be using the id

Note: the clearCache() method to clear the entire cache was working correctly, however I think this must have been copy/pasted to the clearCache(String) method and not correctly tidied up

Note I changed the synchronized statement to synchronize on the systemcache instead of the scope map. I assume this is correct but I am no expert on concurrency!
